### PR TITLE
Adding option to not show the cover in viewer

### DIFF
--- a/src/calibre/ebooks/oeb/iterator/book.py
+++ b/src/calibre/ebooks/oeb/iterator/book.py
@@ -49,8 +49,9 @@ class EbookIterator(BookmarksMixin):
 
     CHARACTERS_PER_PAGE = 1000
 
-    def __init__(self, pathtoebook, log=None):
+    def __init__(self, pathtoebook, exclude_cover=False, log=None):
         self.log = log or default_log
+        self.exclude_cover = exclude_cover
         pathtoebook = pathtoebook.strip()
         self.pathtoebook = os.path.abspath(pathtoebook)
         self.config = DynamicConfig(name='iterator')
@@ -142,16 +143,20 @@ class EbookIterator(BookmarksMixin):
                 self.log.warn('Missing spine item:', repr(spath))
 
         cover = self.opf.cover
-        if cover and self.ebook_ext in {'lit', 'mobi', 'prc', 'opf', 'fb2',
-                                        'azw', 'azw3'}:
-            cfile = os.path.join(self.base, 'calibre_iterator_cover.html')
-            rcpath = os.path.relpath(cover, self.base).replace(os.sep, '/')
-            chtml = (TITLEPAGE%prepare_string_for_xml(rcpath, True)).encode('utf-8')
-            with open(cfile, 'wb') as f:
-                f.write(chtml)
-            self.spine[0:0] = [Spiny(cfile,
-                mime_type='application/xhtml+xml')]
-            self.delete_on_exit.append(cfile)
+        if cover:
+            if self.ebook_ext in {'lit', 'mobi', 'prc', 'opf', 'fb2',
+                    'azw', 'azw3'}:
+                if not self.exclude_cover:
+                    cfile = os.path.join(self.base, 'calibre_iterator_cover.html')
+                    rcpath = os.path.relpath(cover, self.base).replace(os.sep, '/')
+                    chtml = (TITLEPAGE%prepare_string_for_xml(rcpath, True)).encode('utf-8')
+                    with open(cfile, 'wb') as f:
+                        f.write(chtml)
+                    self.spine[0:0] = [Spiny(cfile,
+                        mime_type='application/xhtml+xml')]
+                    self.delete_on_exit.append(cfile)             
+            elif self.exclude_cover:
+                self.spine.remove(cover)
 
         if self.opf.path_to_html_toc is not None and \
            self.opf.path_to_html_toc not in self.spine:

--- a/src/calibre/gui2/viewer/config.py
+++ b/src/calibre/gui2/viewer/config.py
@@ -41,6 +41,8 @@ def config(defaults=None):
             help=_('Default language for hyphenation rules'))
     c.add_opt('remember_current_page', default=True,
             help=_('Save the current position in the document, when quitting'))
+    c.add_opt('dont_show_cover', default=False,
+            help=_('Don\'t show the cover.'))
     c.add_opt('wheel_flips_pages', default=False,
             help=_('Have the mouse wheel turn pages'))
     c.add_opt('line_scrolling_stops_on_pagebreaks', default=False,
@@ -183,6 +185,7 @@ class ConfigDialog(QDialog, Ui_Dialog):
     def load_options(self, opts):
         self.opt_remember_window_size.setChecked(opts.remember_window_size)
         self.opt_remember_current_page.setChecked(opts.remember_current_page)
+        self.opt_dont_show_cover.setChecked(opts.dont_show_cover)
         self.opt_wheel_flips_pages.setChecked(opts.wheel_flips_pages)
         self.opt_page_flip_duration.setValue(opts.page_flip_duration)
         fms = opts.font_magnification_step
@@ -278,6 +281,7 @@ class ConfigDialog(QDialog, Ui_Dialog):
         c.set('max_fs_width', int(self.max_fs_width.value()))
         c.set('hyphenate', self.hyphenate.isChecked())
         c.set('remember_current_page', self.opt_remember_current_page.isChecked())
+        c.set('dont_show_cover', self.opt_dont_show_cover.isChecked())
         c.set('wheel_flips_pages', self.opt_wheel_flips_pages.isChecked())
         c.set('page_flip_duration', self.opt_page_flip_duration.value())
         c.set('font_magnification_step',

--- a/src/calibre/gui2/viewer/config.ui
+++ b/src/calibre/gui2/viewer/config.ui
@@ -649,6 +649,13 @@ QToolBox::tab:hover {
              </property>
             </widget>
            </item>
+           <item row="5" column="0" colspan="2">
+            <widget class="QCheckBox" name="opt_dont_show_cover">
+             <property name="text">
+              <string>Don't show the c&amp;over (needs restart)</string>
+             </property>
+            </widget>
+           </item>
           </layout>
          </widget>
         </widget>

--- a/src/calibre/gui2/viewer/main.py
+++ b/src/calibre/gui2/viewer/main.py
@@ -486,6 +486,11 @@ class EbookViewer(MainWindow, Ui_EbookViewer):
         c = config().parse()
         return c.remember_current_page
 
+    def get_dont_show_cover_opt(self):
+        from calibre.gui2.viewer.documentview import config
+        c = config().parse()
+        return c.dont_show_cover
+        
     def print_book(self):
         p = Printing(self.iterator, self)
         p.start_print()
@@ -982,7 +987,7 @@ class EbookViewer(MainWindow, Ui_EbookViewer):
         if self.iterator is not None:
             self.save_current_position()
             self.iterator.__exit__()
-        self.iterator = EbookIterator(pathtoebook)
+        self.iterator = EbookIterator(pathtoebook, self.get_dont_show_cover_opt())
         self.open_progress_indicator(_('Loading ebook...'))
         worker = Worker(target=partial(self.iterator.__enter__,
             extract_embedded_fonts_for_qt=True))


### PR DESCRIPTION
The option is especially useful for users that auto convert to mobi to avoid page changes (because the mobi book page is large it takes around 5 s to change from the cover page to the book page).

> I decided to remove the hide cover implementation as it breaks bookmarking. Bookmarks that are created with that option set will not work with the option unset.

A patch for this is welcome
