### PR TITLE
Changing datetime to QDate to avoid conversion and extend the range

### DIFF
--- a/src/calibre/ebooks/metadata/opf2.py
+++ b/src/calibre/ebooks/metadata/opf2.py
@@ -1440,7 +1440,7 @@ def metadata_to_opf(mi, as_string=True, default_lang=None):
     for au in mi.authors:
         factory(DC('creator'), au, mi.author_sort, 'aut')
     factory(DC('contributor'), mi.book_producer, __appname__, 'bkp')
-    if hasattr(mi.pubdate, 'isoformat'):
+    if hasattr(mi.pubdate, 'toString'):
         factory(DC('date'), isoformat(mi.pubdate))
     if hasattr(mi, 'category') and mi.category:
         factory(DC('type'), mi.category)
@@ -1468,7 +1468,7 @@ def metadata_to_opf(mi, as_string=True, default_lang=None):
         meta('series_index', mi.format_series_index())
     if mi.rating is not None:
         meta('rating', str(mi.rating))
-    if hasattr(mi.timestamp, 'isoformat'):
+    if hasattr(mi.timestamp, 'toString'):
         meta('timestamp', isoformat(mi.timestamp))
     if mi.publication_type:
         meta('publication_type', mi.publication_type)

--- a/src/calibre/ebooks/metadata/sources/identify.py
+++ b/src/calibre/ebooks/metadata/sources/identify.py
@@ -322,6 +322,8 @@ class ISBNMerge(object):
             if min_date.year < 3000:
                 ans.pubdate = min_date
 
+        ans.pubdate = r.pubdate
+                
         # Identifiers
         for r in results:
             ans.identifiers.update(r.identifiers)
@@ -495,8 +497,6 @@ def identify(log, abort, # {{{
     max_tags = msprefs['max_tags']
     for r in results:
         r.tags = r.tags[:max_tags]
-        if getattr(r.pubdate, 'year', 2000) <= UNDEFINED_DATE.year:
-            r.pubdate = None
 
     if msprefs['swap_author_names']:
         for r in results:

--- a/src/calibre/gui2/library/delegates.py
+++ b/src/calibre/gui2/library/delegates.py
@@ -74,7 +74,7 @@ class DateDelegate(QStyledItemDelegate): # {{{
         d = val.toDateTime()
         if d <= UNDEFINED_QDATETIME:
             return ''
-        return format_date(qt_to_dt(d, as_utc=False), self.format)
+        return format_date(d, self.format)
 
     def createEditor(self, parent, option, index):
         qde = QStyledItemDelegate.createEditor(self, parent, option, index)
@@ -96,9 +96,7 @@ class PubDateDelegate(QStyledItemDelegate): # {{{
 
     def displayText(self, val, locale):
         d = val.toDateTime()
-        if d <= UNDEFINED_QDATETIME:
-            return ''
-        return format_date(qt_to_dt(d, as_utc=False), self.format)
+        return format_date(d, self.format)
 
     def createEditor(self, parent, option, index):
         qde = QStyledItemDelegate.createEditor(self, parent, option, index)

--- a/src/calibre/library/database2.py
+++ b/src/calibre/library/database2.py
@@ -34,7 +34,7 @@ from calibre import isbytestring
 from calibre.utils.filenames import (ascii_filename, samefile,
         WindowsAtomicFolderMove, hardlink_file)
 from calibre.utils.date import (utcnow, now as nowf, utcfromtimestamp,
-        parse_only_date, UNDEFINED_DATE)
+        parse_only_date, isoformat, UNDEFINED_DATE)
 from calibre.utils.config import prefs, tweaks, from_json, to_json
 from calibre.utils.icu import sort_key, strcmp, lower
 from calibre.utils.search_query_parser import saved_searches, set_saved_searches
@@ -2565,7 +2565,7 @@ class LibraryDatabase2(LibraryDatabase, SchemaUpgrade, CustomColumns):
 
     def set_timestamp(self, id, dt, notify=True, commit=True):
         if dt:
-            self.conn.execute('UPDATE books SET timestamp=? WHERE id=?', (dt, id))
+            self.conn.execute("UPDATE books SET timestamp='{}' WHERE id={}".format(isoformat(dt, time=True), id))
             self.data.set(id, self.FIELD_MAP['timestamp'], dt, row_is_id=True)
             self.dirtied([id], commit=False)
             if commit:
@@ -2578,7 +2578,7 @@ class LibraryDatabase2(LibraryDatabase, SchemaUpgrade, CustomColumns):
             dt = UNDEFINED_DATE
         if isinstance(dt, basestring):
             dt = parse_only_date(dt)
-        self.conn.execute('UPDATE books SET pubdate=? WHERE id=?', (dt, id))
+        self.conn.execute("UPDATE books SET pubdate='{}' WHERE id={}".format(isoformat(dt, time=True), id))
         self.data.set(id, self.FIELD_MAP['pubdate'], dt, row_is_id=True)
         self.dirtied([id], commit=False)
         if commit:


### PR DESCRIPTION
I argue that
- using QDate rather than datetime remove the need to convert between them which simplify the code
- QDate is preferable to datetime for a library because the minimum year is -4713 contra 1
- there's no significant disadvantage with using QDate rather than datetime
