### PR TITLE
Changing default book table home/end scrolling from horizontal to vertical 

### DIFF
--- a/src/calibre/gui2/library/views.py
+++ b/src/calibre/gui2/library/views.py
@@ -761,6 +761,21 @@ class BooksView(QTableView): # {{{
 
     # }}}
 
+    def keyPressEvent(self, event):
+        # change default home/end scrolling from horizontal to vertical
+        if event.key() == Qt.Key_Home:
+            if event.modifiers() == Qt.ControlModifier:
+                self.horizontalScrollBar().setValue(0)
+            else:
+                self.set_current_row(0)
+        elif event.key() == Qt.Key_End:
+            if event.modifiers() == Qt.ControlModifier:
+                self.horizontalScrollBar().setValue(self.model().columnCount(QModelIndex())-1)
+            else:
+                self.set_current_row(self.model().rowCount(QModelIndex())-1)
+        else:
+            return super(BooksView, self).keyPressEvent(event)
+    
     @property
     def column_map(self):
         return self._model.column_map


### PR DESCRIPTION
> … I see no good reason why they should be remapped to move to the first and last row instead…

I argue that
- scrolling up/down is a more common action for home/end in
  - in general tables that are not often edited, f.e. in contrast to
    - a spreadsheet program where cells are more often edited than in the book table
  - in specific in the book table because
    - there's an incentive to limit the horizontal so that there's limited horizontal scrolling because horizontal scrolling can be seen as annoying
    - there's an incentive to have relatively many items in the table, sometimes more items than what fit in the window height

> carefully chosen by the Qt developers … platform specific quirks

I argue that there's no platform consideration because
- it's not obvious what platform or circumstance that would be

I argue that the the logical basis for connecting home/end to horizontal scrolling is that this action is more common because
- the widget (in this case the `QTableView`) is more often wide than high
- another action than scrolling to top/bottom is more common, f.e.
  - in Excel scrolling to the first column is considered more common than scrolling to top (so that this action is connected to home and a modifier + home scroll to top) an for consistency scrolling to bottom use the same modifier as scrolling to top (end is used for 'End Mode')
