### PR TITLE
Renaming the font size controls to a more natural language

### DIFF
--- a/src/calibre/gui2/viewer/documentview.py
+++ b/src/calibre/gui2/viewer/documentview.py
@@ -544,7 +544,7 @@ class DocumentView(QWebView): # {{{
         self.goto_location_action.setMenu(self.goto_location_menu)
         self.grabGesture(Qt.SwipeGesture)
 
-        self.restore_fonts_action = QAction(_('Normal font size'), self)
+        self.restore_fonts_action = QAction(_('Default font size'), self)
         self.restore_fonts_action.setCheckable(True)
         self.restore_fonts_action.triggered.connect(self.restore_font_size)
 

--- a/src/calibre/gui2/viewer/main.py
+++ b/src/calibre/gui2/viewer/main.py
@@ -697,11 +697,11 @@ class EbookViewer(MainWindow, Ui_EbookViewer):
         self.view.shrink_fonts()
 
     def magnification_changed(self, val):
-        tt = _('Make font size %(which)s\nCurrent magnification: %(mag).1f')
+        tt = _('%(which)s font size\nCurrent magnification: %(mag).1f')
         self.action_font_size_larger.setToolTip(
-                tt %dict(which=_('larger'), mag=val))
+                tt %dict(which=_('Increase'), mag=val))
         self.action_font_size_smaller.setToolTip(
-                tt %dict(which=_('smaller'), mag=val))
+                tt %dict(which=_('Decrease'), mag=val))
         self.action_font_size_larger.setEnabled(self.view.multiplier < 3)
         self.action_font_size_smaller.setEnabled(self.view.multiplier > 0.2)
 

--- a/src/calibre/gui2/viewer/main.ui
+++ b/src/calibre/gui2/viewer/main.ui
@@ -198,7 +198,7 @@
      <normaloff>:/images/font_size_larger.png</normaloff>:/images/font_size_larger.png</iconset>
    </property>
    <property name="text">
-    <string>Font size larger</string>
+    <string>Increase font size</string>
    </property>
   </action>
   <action name="action_font_size_smaller">
@@ -207,7 +207,7 @@
      <normaloff>:/images/font_size_smaller.png</normaloff>:/images/font_size_smaller.png</iconset>
    </property>
    <property name="text">
-    <string>Font size smaller</string>
+    <string>Decrease font size</string>
    </property>
   </action>
   <action name="action_table_of_contents">


### PR DESCRIPTION
#### Patch

The text is changed from `make font size larger/smaller` to `increase/decrease font size`
#### Authorship review

I ask for an authorship review for https://github.com/mirror/calibre/commit/1654b06e151421edae253d3fc5ab9d7be43b11ff#src/calibre/gui2/viewer/documentview.py with the goal of determining its author because
- it's identical to this patch
- it's committed soon after this patch was published

> [2013-02-01 05:16:05 comment](https://bugs.launchpad.net/calibre/+bug/1112123) summarized: I don't dispute the authorship claim

I argue that the author should be corrected because
- the reasoned arguments in this text about [authorship review](https://www.dropbox.com/sh/2z5p162ovqtbn17/zmlj-UPGdQ/note/author.md) are that if the authorship claim isn't disputed the author should be corrected
- it's not a significant inconvenience to do so because the commands for it are given (below)

and by
- reverting the commit with wrong author

<!-- -->

```
bzr switch -b author
s=13952
bzr merge -r$s..$(($s-1)) .
bzr commit -m"Reverting $s to change author"
```
- creating a commit with the right author with `bzr git-apply`

<!-- -->

```
curl https://github.com/john-peterson/calibre/commit/582ddfbf1a959421e1aa1a25d3d990f76fee8962.patch>/tmp/patch; bzr git-apply /tmp/patch
```
- or asking me to push to launchpad with `git bzr push`
