### PR TITLE
Making Windows build archive folders extractable

### DIFF
--- a/setup/installer/windows/freeze.py
+++ b/setup/installer/windows/freeze.py
@@ -667,7 +667,6 @@ class Win32Freeze(Command, WixMixIn):
 
     def add_to_zipfile(self, zf, name, base, exclude=frozenset()):
         abspath = self.j(base, name)
-        name = name.replace(os.sep, '/')
         if name in self.zf_names:
             raise ValueError('Already added %r to zipfile [%r]'%(name, abspath))
         zinfo = zipfile.ZipInfo(filename=name, date_time=self.zf_timestamp)
@@ -675,8 +674,6 @@ class Win32Freeze(Command, WixMixIn):
         if os.path.isdir(abspath):
             if not os.listdir(abspath):
                 return
-            zinfo.external_attr = 0700 << 16
-            zf.writestr(zinfo, '')
             for x in os.listdir(abspath):
                 if x not in exclude:
                     self.add_to_zipfile(zf, name + os.sep + x, base)


### PR DESCRIPTION
#### Directory entry

Removing archive directory entries because they're unnecessary because the archive is valid (equivalent to `zip -rD`) without it.

The current directory entry also lack a trailing slash so that it's treated as a file by `unzip` and `7z` (and `winrar.exe`) so that directories can't be extracted as explained below.
##### Benefit

It's beneficial to be able to extract files from `calibre-0.9.17.msi/PFiles/calibre/pylib.zip`  because
- the Windows build archive contain many [dependencies](https://github.com/mirror/calibre/blob/master/setup/installer/windows/notes.rst) (which it's relatively laborious to build) so that it's more efficient to replace `pylib.zip/calibre` to create a build that's (compared to a `CALIBRE_DEVELOP_FROM` build)
  - easier to copy because it's fewer files
  - load faster because the code is compiled
  - doesn't require an environment variable
- the files can be placed in the path from which  `python setup.py win32_freeze` copy the files so that the command can create a runnable archive
- copying changes to the distributed archive is easier if they can be extracted from a `python setup.py win32_freeze` archive (rather than being copied by another script that perform a similar task)
#### File entry slash

`name.replace(os.sep, '/')` is removed because it's uncessary because [`ZipInfo` does that](http://hg.python.org/cpython/file/2.7/Lib/zipfile.py#l298).
### Zip directory entries

Without a trailing slash the folder entry is [treated as a file](https://github.com/mirror/sevenzip/blob/master/CPP/7zip/Archive/Zip/ZipItem.cpp#L86) (despite a directory `external_attr`) so that `unzip` and `7z` return

```
unzip archive.zip
    checkdir error:  file/folder exists but is not directory
                     unable to process folder/file.

7z x archive.zip
Extracting  folder
can not open output file archive/folder/file

7z l -slt archive.zip
Path = folder
Folder = -
Attributes = D....
```

Even if some programs identify directory entries by a trailing slash instead of the external attribute it's still beneficial to have a correct external attribute for the sake of order. The [directory `external_attr` bits are](http://unix.stackexchange.com/questions/14705/the-zip-formats-external-file-attribute)

```
0x40000010
  ^     ^
  |     DOS folder
  UNIX folder
```

so that the correct directory entry creation is

```
zinfo.external_attr = 040700 << 16L | 0x0010
zf.writestr(zinfo, '')
```
#### Notes

It can also be mentioned that the reason to set `external_attr` (rather than not set it) is that otherwise the [`os.stat` is used](http://hg.python.org/cpython/file/2.7/Lib/zipfile.py#l1124) attribute is used (when the [argument is a `ZipInfo` object](http://hg.python.org/cpython/file/2.7/Lib/zipfile.py#l1194)) which might have unwanted attributes.
