### PR TITLE
Print error if `coffee` is missing rather than open the editor

### DIFF
--- a/setup/check.py
+++ b/setup/check.py
@@ -95,11 +95,7 @@ class Check(Command):
                     errors = True
                     self.report_errors(w)
             else:
-                try:
-                    subprocess.check_call(['coffee', '-c', '-p', f],
-                            stdout=open(os.devnull, 'wb'))
-                except:
-                    errors = True
+                subprocess.check_call(['coffee', '-c', '-p', f], stdout=open(os.devnull, 'wb'))
             if errors:
                 cPickle.dump(cache, open(self.CACHE, 'wb'), -1)
                 subprocess.call(['gvim', '-S',


### PR DESCRIPTION
Placing `check_call` on a single line so that the call is visible in 'Traceback'
