### PR TITLE
Adding missing directory creation to build, changing python26 to python27

### DIFF
--- a/setup/extensions.py
+++ b/setup/extensions.py
@@ -535,6 +535,8 @@ class Build(Command):
             src = (glob.glob('*.so') + glob.glob('release/*.dll') +
                     glob.glob('*.dylib'))
             ext = 'pyd' if iswindows else 'so'
+            if not os.path.exists(dest):
+                os.makedirs(dest)
             shutil.copy2(src[0], self.j(dest, 'calibre_style.'+ext))
         finally:
             os.chdir(ocwd)

--- a/setup/installer/linux/freeze2.py
+++ b/setup/installer/linux/freeze2.py
@@ -238,7 +238,10 @@ class LinuxFreeze(Command):
 
     def create_tarfile(self):
         self.info('Creating archive...')
-        dist = os.path.join(self.d(self.SRC), 'dist',
+        dest = 'dist'
+        if not os.path.exists(dest):
+            os.makedirs(dest)
+        dist = os.path.join(self.d(self.SRC), dest,
             '%s-%s-%s.tar.bz2'%(__appname__, __version__, arch))
         with tarfile.open(dist, mode='w:bz2',
                     format=tarfile.PAX_FORMAT) as tf:

--- a/src/calibre/utils/windows/Makefile
+++ b/src/calibre/utils/windows/Makefile
@@ -2,18 +2,18 @@
 # Invoke with nmake /f  Makefile.winutil
 
 test : winutil.pyd
-    \python26\python.exe -c "import winutil; winutil.set_debug(True); print repr(winutil.strftime(u'%b %a %A')); "
+    \python27\python.exe -c "import winutil; winutil.set_debug(True); print repr(winutil.strftime(u'%b %a %A')); "
 #python.exe -c "import winutil; winutil.set_debug(True); print winutil.get_usb_devices(); print winutil.get_mounted_volumes_for_usb_device(0x054c, 0x031e)"
 
 winutil.pyd : winutil.obj
-	link.exe /DLL /nologo /INCREMENTAL:NO /LIBPATH:c:\Python26\libs \
-	/LIBPATH:c:\Python26\PCBuild shell32.lib setupapi.lib 	Wininet.lib /EXPORT:initwinutil \
+	link.exe /DLL /nologo /INCREMENTAL:NO /LIBPATH:c:\Python27\libs \
+	/LIBPATH:c:\Python27\PCBuild shell32.lib setupapi.lib 	Wininet.lib /EXPORT:initwinutil \
 	winutil.obj /OUT:winutil.pyd
 
 
 winutil.obj : winutil.c
-	cl.exe /c /nologo /Ox /MD /W3 /GX /DNDEBUG -Ic:\Python26\include \
-	-Ic:\Python26\PC -Ic:\WinDDK\6001.18001\inc\api /Tcwinutil.c /Fowinutil.obj
+	cl.exe /c /nologo /Ox /MD /W3 /GX /DNDEBUG -Ic:\Python27\include \
+	-Ic:\Python27\PC -Ic:\WinDDK\6001.18001\inc\api /Tcwinutil.c /Fowinutil.obj
 
 clean :
 	del winutil.pyd winutil.obj winutil.exp winutil.lib


### PR DESCRIPTION
#### Reproduce

```
git clean -fxd
python2.7 setup.py stage1
IOError: [Errno 2] No such file or directory: '/home/user/repo/calibre/src/calibre/plugins/calibre_style.so'
```

or another setup that run `build` such as `python2.7 setup.py build`, `python2.7 setup.py install`, `python2.7 setup.py develop`

```
git clean -fxd
python2.7 setup.py linux_freeze
IOError: [Errno 2] No such file or directory: '/root/calibre/dist/calibre-0.9.17-x86_64.tar.bz2'
```
