### PR TITLE
Printing `calibre-parallel` output

### DIFF
--- a/src/calibre/ebooks/metadata/pdf.py
+++ b/src/calibre/ebooks/metadata/pdf.py
@@ -87,10 +87,6 @@ def get_metadata(stream, cover=True):
             prints(e.orig_tb)
             raise RuntimeError('Failed to run pdfinfo')
         info = res['result']
-        with open(res['stdout_stderr'], 'rb') as f:
-            raw = f.read().strip()
-            if raw:
-                prints(raw)
         if not info:
             raise ValueError('Could not read info dict from PDF')
         covpath = os.path.join(pdfpath, 'cover.jpg')

--- a/src/calibre/ebooks/metadata/sources/identify.py
+++ b/src/calibre/ebooks/metadata/sources/identify.py
@@ -7,7 +7,7 @@ __license__   = 'GPL v3'
 __copyright__ = '2011, Kovid Goyal <kovid@kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
-import time
+import time, traceback
 from datetime import datetime
 from Queue import Queue, Empty
 from threading import Thread
@@ -41,6 +41,7 @@ class Worker(Thread):
         try:
             self.plugin.identify(self.log, self.rq, self.abort, **self.kwargs)
         except:
+            traceback.print_exc()
             self.log.exception('Plugin', self.plugin.name, 'failed')
         self.plugin.dl_time_spent = time.time() - start
 

--- a/src/calibre/ebooks/metadata/sources/worker.py
+++ b/src/calibre/ebooks/metadata/sources/worker.py
@@ -7,7 +7,7 @@ __license__   = 'GPL v3'
 __copyright__ = '2012, Kovid Goyal <kovid@kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
-import os
+import os, traceback
 from threading import Event, Thread
 from Queue import Queue, Empty
 from io import BytesIO
@@ -68,7 +68,7 @@ def main(do_identify, covers, metadata, ensure_fields, tdir):
                 results = identify(log, Event(), title=title, authors=authors,
                     identifiers=identifiers)
             except:
-                pass
+                traceback.print_exc()
             if results:
                 all_failed = False
                 mi = merge_result(mi, results[0], ensure_fields=ensure_fields)

--- a/src/calibre/ebooks/mobi/tweak.py
+++ b/src/calibre/ebooks/mobi/tweak.py
@@ -69,7 +69,7 @@ def explode(path, dest, question=lambda x:True):
                 return None
 
     return fork_job('calibre.ebooks.mobi.tweak', 'do_explode', args=(path,
-            dest), no_output=True)['result']
+            dest))['result']
 
 def set_cover(oeb):
     if 'cover' not in oeb.guide or oeb.metadata['cover']: return
@@ -96,7 +96,6 @@ def rebuild(src_dir, dest_path):
         raise ValueError('No OPF file found in %s'%src_dir)
     opf = opf[0]
     # For debugging, uncomment the following line
-    # def fork_job(a, b, args=None, no_output=True): do_rebuild(*args)
-    fork_job('calibre.ebooks.mobi.tweak', 'do_rebuild', args=(opf, dest_path),
-            no_output=True)
+    # def fork_job(a, b, args=None): do_rebuild(*args)
+    fork_job('calibre.ebooks.mobi.tweak', 'do_rebuild', args=(opf, dest_path))
 

--- a/src/calibre/ebooks/oeb/polish/container.py
+++ b/src/calibre/ebooks/oeb/polish/container.py
@@ -350,7 +350,7 @@ class AZW3Container(Container):
         try:
             opf_path, obfuscated_fonts = fork_job(
             'calibre.ebooks.oeb.polish.container', 'do_explode',
-            args=(pathtoazw3, tdir), no_output=True)['result']
+            args=(pathtoazw3, tdir))['result']
         except WorkerError as e:
             log(e.orig_tb)
             raise InvalidMobi('Failed to explode MOBI')

--- a/src/calibre/gui2/auto_add.py
+++ b/src/calibre/gui2/auto_add.py
@@ -78,7 +78,7 @@ class Worker(Thread):
             tdir = tempfile.mkdtemp(dir=self.tdir)
             try:
                 fork_job('calibre.ebooks.metadata.meta',
-                        'forked_read_metadata', (f, tdir), no_output=True)
+                        'forked_read_metadata', (f, tdir))
             except WorkerError as e:
                 prints('Failed to read metadata from:', fname)
                 prints(e.orig_tb)

--- a/src/calibre/gui2/metadata/bulk_download.py
+++ b/src/calibre/gui2/metadata/bulk_download.py
@@ -233,7 +233,7 @@ def download(all_ids, tf, db, do_identify, covers, ensure_fields,
             try:
                 ret = fork_job('calibre.ebooks.metadata.sources.worker', 'main',
                         (do_identify, covers, metadata, ensure_fields, tdir),
-                        abort=abort, heartbeat=heartbeat, no_output=True)
+                        abort=abort, heartbeat=heartbeat)
             except WorkerError as e:
                 if e.orig_tb:
                     raise Exception('Failed to download metadata. Original '

--- a/src/calibre/gui2/metadata/single_download.py
+++ b/src/calibre/gui2/metadata/single_download.py
@@ -417,7 +417,7 @@ class IdentifyWorker(Thread): # {{{
                 res = fork_job(
                         'calibre.ebooks.metadata.sources.worker',
                         'single_identify', (self.title, self.authors,
-                            self.identifiers), no_output=True, abort=self.abort)
+                            self.identifiers), abort=self.abort)
                 self.results, covers, caches, log_dump = res['result']
                 self.results = [OPF(BytesIO(r), basedir=os.getcwdu(),
                     populate_spine=False).to_book_metadata() for r in self.results]
@@ -594,8 +594,7 @@ class CoverWorker(Thread): # {{{
                 res = fork_job('calibre.ebooks.metadata.sources.worker',
                     'single_covers',
                     (self.title, self.authors, self.identifiers, self.caches,
-                        tdir),
-                    no_output=True, abort=self.abort)
+                        tdir), abort=self.abort)
                 self.log.append_dump(res['result'])
             finally:
                 self.keep_going = False

--- a/src/calibre/utils/ipc/launch.py
+++ b/src/calibre/utils/ipc/launch.py
@@ -120,14 +120,12 @@ class Worker(object):
         if not hasattr(self, 'child'): return None
         return getattr(self.child, 'pid', None)
 
-    def close_log_file(self):
-        try:
-            self._file.close()
-        except:
-            pass
+    def print_output(self):
+        out, err = self.child.communicate()
+        print out, '\n', err
 
     def kill(self):
-        self.close_log_file()
+        self.print_output()
         try:
             if self.is_alive:
                 if iswindows:
@@ -192,12 +190,10 @@ class Worker(object):
             args['preexec_fn'] = partial(renice, niceness)
         ret = None
         if redirect_output:
-            self._file = PersistentTemporaryFile('_worker_redirect.log')
-            args['stdout'] = self._file._fd
+            args['stdout'] = subprocess.PIPE
             args['stderr'] = subprocess.STDOUT
             if iswindows:
                 args['stdin'] = subprocess.PIPE
-            ret = self._file.name
 
         if iswindows and 'stdin' not in args:
             # On windows when using the pythonw interpreter,
@@ -215,9 +211,5 @@ class Worker(object):
         self.child = subprocess.Popen(cmd, **args)
         if 'stdin' in args:
             self.child.stdin.close()
-
-        self.log_path = ret
-        return ret
-
 
 

--- a/src/calibre/utils/ipc/simple_worker.py
+++ b/src/calibre/utils/ipc/simple_worker.py
@@ -84,7 +84,7 @@ def communicate(ans, worker, listener, args, timeout=300, heartbeat=None,
     ans['result'] = cw.res['result']
 
 def fork_job(mod_name, func_name, args=(), kwargs={}, timeout=300, # seconds
-        cwd=None, priority='normal', env={}, no_output=False, heartbeat=None,
+        cwd=None, priority='normal', env={}, heartbeat=None,
         abort=None, module_is_source_code=False):
     '''
     Run a job in a worker process. A job is simply a function that will be
@@ -112,9 +112,6 @@ def fork_job(mod_name, func_name, args=(), kwargs={}, timeout=300, # seconds
 
     :param env: Extra environment variables to set for the worker process
 
-    :param no_output: If True, the stdout and stderr of the worker process are
-    discarded
-
     :param heartbeat: If not None, it is used to check if the worker has hung,
     instead of a simple timeout. It must be a callable that takes no
     arguments and returns True or False. The worker will be assumed to have
@@ -132,7 +129,6 @@ def fork_job(mod_name, func_name, args=(), kwargs={}, timeout=300, # seconds
     :return: A dictionary with the keys result and stdout_stderr. result is the
     return value of the function (it must be picklable). stdout_stderr is the
     path to a file that contains the stdout and stderr of the worker process.
-    If you set no_output=True, then this will not be present.
     '''
 
     ans = {'result':None, 'stdout_stderr':None}
@@ -162,13 +158,6 @@ def fork_job(mod_name, func_name, args=(), kwargs={}, timeout=300, # seconds
         t = Thread(target=w.kill)
         t.daemon=True
         t.start()
-        if no_output:
-            try:
-                os.remove(w.log_path)
-            except:
-                pass
-    if not no_output:
-        ans['stdout_stderr'] = w.log_path
     return ans
 
 def compile_code(src):

--- a/src/calibre/utils/serve_coffee.py
+++ b/src/calibre/utils/serve_coffee.py
@@ -98,7 +98,7 @@ def compile_coffeescript(raw, filename=None):
     except NameError:
         from calibre.utils.ipc.simple_worker import fork_job
         return fork_job('calibre.utils.serve_coffee', 'do_compile',
-                args=(raw,), no_output=True)['result']
+                args=(raw,))['result']
 
 class HTTPRequestHandler(SimpleHTTPRequestHandler): # {{{
     '''


### PR DESCRIPTION
### Changing `calibre-parallel` output connection

The goal is to print stderr and stdout from `calibre-parallel` because
- it helps locating errors (compared to not seeing stderr and stdout)

The IPC is changed from a file to pipe because the `subprocess` output doesn't reach the file in these tests (in Ubuntu and Windows).

```
utils/ipc/worker.py
def main():
    print 'test_stdout'
    test_stderr

utils/ipc/launch.py
def close_log_file(self):
    print 'close_log_file: ', self._file.name
    statinfo = os.stat(self._file.name)
    print 'st_size: ', statinfo.st_size

close_log_file:  /tmp/calibre_0.9.17_tmp_aubqLb/MOg4Qh_worker_redirect.log
st_size:  0

close_log_file:  C:\Documents\Programs\cygwin\tmp\calibre_0.9.17_tmp_u3r0s4\1sdfrk_worker_redirect.log
st_size:  0
```

The data doesn't reach the file with other `subprocess` argument variations either

```
        # args['stdout'] = subprocess.STDOUT
        args['stderr'] = self._file._fd

        args['stdout'] = self._file._fd
        args['stderr'] = self._file._fd

        OSError: [Errno 2] No such file or directory: '/tmp/calibre_0.9.17_tmp_KsLrq0/GMt72S_worker_redirect.log'
```
### Adding missing exception message

It's beneficial to print the exception because
- it helps locating the error because the file and line is given
### Removing IPC file

If communication is done through a file (rather than a pipe) the removal should wait for the file handle to be closed because this call

```
utils/ipc/simple_worker.py
def fork_job
    finally:
        os.remove(w.log_path)
```

doesn't wait for

```
utils/ipc/launch.py
def close_log_file(self):
    self._file.close()
```

in Windows so that the folder is not removed

```
WindowsError: [Error 32] The process cannot access the file because it is being used by another process: u'C:\\Documents\\Programs\\cygwin\\tmp\\calibre_0.9.17_tmp_fi77r4\\tkzkeh_worker_redirect.log'

ls /tmp|grep calibre|wc -l
862 
ls -t /tmp|grep calibre|tail -1
drwxr-xr-x 1 User None        0 2012-10-27 22:42 calibre_0.9.4_tmp_0i3o3j
ls -t /tmp|grep calibre|head -1
drwxr-xr-x 1 User None        0 2013-02-07 01:18 calibre_0.9.17_tmp_fi77r4
```
